### PR TITLE
Feature/synthetic hold

### DIFF
--- a/vocode/streaming/agent/base_agent.py
+++ b/vocode/streaming/agent/base_agent.py
@@ -7,7 +7,6 @@ import logging
 import random
 from typing import (
     AsyncGenerator,
-    Generator,
     Generic,
     Optional,
     Tuple,
@@ -28,7 +27,6 @@ from vocode.streaming.models.actions import (
     ActionInput,
     ActionOutput,
     FunctionCall,
-    FunctionFragment,
 )
 
 from vocode.streaming.models.agent import (

--- a/vocode/streaming/models/synthetic_hold.py
+++ b/vocode/streaming/models/synthetic_hold.py
@@ -1,0 +1,11 @@
+from typing import (
+  List,
+  Optional
+)
+from pydantic import BaseModel
+
+class SyntheticHoldConfig(BaseModel):
+  enabled: bool = True
+  audio_url: Optional[str]
+  preflight_messages:  List[str] = []
+  resume_messages: List[str] = []

--- a/vocode/streaming/output_device/base_output_device.py
+++ b/vocode/streaming/output_device/base_output_device.py
@@ -12,6 +12,9 @@ class BaseOutputDevice:
     def consume_nonblocking(self, chunk: bytes):
         raise NotImplemented
     
+    def clear_stream(self):
+        raise NotImplemented
+
     def maybe_send_mark_nonblocking(self, message):
         pass
 

--- a/vocode/streaming/output_device/twilio_output_device.py
+++ b/vocode/streaming/output_device/twilio_output_device.py
@@ -40,6 +40,13 @@ class TwilioOutputDevice(BaseOutputDevice):
         }
         self.queue.put_nowait(json.dumps(twilio_message))
 
+    def clear_stream(self):
+        twilio_message = {
+            "event": "clear",
+            "streamSid": self.stream_sid
+        }
+        self.queue.put_nowait(json.dumps(twilio_message))
+
     def maybe_send_mark_nonblocking(self, message_sent):
         mark_message = {
             "event": "mark",

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -475,6 +475,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
         self.is_human_speaking = False
         self.active = False
         self.mark_last_action_timestamp()
+        self.is_caller_on_hold = False
 
         self.check_for_idle_task: Optional[asyncio.Task] = None
         self.track_bot_sentiment_task: Optional[asyncio.Task] = None

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -897,8 +897,6 @@ class StreamingConversation(Generic[OutputDeviceType]):
             await self.say_something_to_caller(message=resume_message, is_interruptible=False)
         else:
             self.logger.debug("No resume messages for this tool.")
-            self.output_device.clear_stream()
-            self.logger.debug("end synthetic hold audio")
 
     def start_on_hold(self, hold_config: SyntheticHoldConfig):
         # sanity check

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -886,17 +886,9 @@ class StreamingConversation(Generic[OutputDeviceType]):
                     audio = audio_generator.__next__()
                 finally:
                     self.output_device.consume_nonblocking(audio)
-            await asyncio.sleep(.5)
+            await asyncio.sleep(1)
         self.output_device.clear_stream()
         self.logger.debug("end synthetic hold audio")
-       
-        resume_messages = hold_config.resume_messages
-        if resume_messages.__len__() > 0:
-            resume_message = resume_messages[random.randint(0, resume_messages.__len__() - 1)]
-            self.logger.debug(f"selected resume message: [{resume_message}]")
-            await self.say_something_to_caller(message=resume_message, is_interruptible=False)
-        else:
-            self.logger.debug("No resume messages for this tool.")
 
     def start_on_hold(self, hold_config: SyntheticHoldConfig):
         # sanity check

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -553,6 +553,8 @@ class StreamingConversation(Generic[OutputDeviceType]):
              len(self.agent.get_agent_config().reengage_options) > 0)
         ):
             self.human_prompt_checker = asyncio.create_task(self.check_if_human_should_be_prompted())
+        else:
+            self.logger.debug(f"re-engagement disabled")
 
     async def send_initial_message(self, initial_message: BaseMessage):
         # TODO: configure if initial message is interruptible

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -831,7 +831,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
         self.mark_last_agent_response()
         self.logger.debug("end spoofing re-engagement")
 
-    def __load_remote_audio(self, audio_url: str, chunk_size = 8000):
+    def __load_remote_audio(self, audio_url: str, chunk_size = 16000):
         """loads remote wav file and returns the bytes in specified chunk size.
         Bytes are converted to 8000hz and mulaw encoded per Twilio spec"""
 

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -824,7 +824,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
 
         self.logger.debug("start spoofing re-engagement")
         agent_reengage_interval = self.agent.get_agent_config().reengage_timeout
-        spoof_last_agent_interval = 1 if agent_reengage_interval > 1 else agent_reengage_interval * .75
+        spoof_last_agent_interval = 1 if agent_reengage_interval is not None and agent_reengage_interval > 1 else agent_reengage_interval * .75
         while self.is_caller_on_hold:
             self.mark_last_agent_response()
             await asyncio.sleep(spoof_last_agent_interval)

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -821,9 +821,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
         self.logger.debug("stopped check if human should be prompted")
 
     async def __on_hold_task(self):
-        """
-        Don't call directly, launch task via calling StreamingConversation.start_on_hold
-        """
+        """Don't call directly, launch task via calling StreamingConversation.start_on_hold"""
         self.logger.debug("synthetic hold task starting")
         if self.agent.get_agent_config().reengage_timeout < 1:
             spoof_last_agent_interval = self.agent.get_agent_config().reengage_timeout * .75

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -824,7 +824,10 @@ class StreamingConversation(Generic[OutputDeviceType]):
 
         self.logger.debug("start spoofing re-engagement")
         agent_reengage_interval = self.agent.get_agent_config().reengage_timeout
-        spoof_last_agent_interval = 1 if agent_reengage_interval is not None and agent_reengage_interval > 1 else agent_reengage_interval * .75
+        if agent_reengage_interval is not None and agent_reengage_interval < 1:
+            spoof_last_agent_interval = agent_reengage_interval * .75
+        else:
+            spoof_last_agent_interval = 1
         while self.is_caller_on_hold:
             self.mark_last_agent_response()
             await asyncio.sleep(spoof_last_agent_interval)

--- a/vocode/streaming/telephony/server/base.py
+++ b/vocode/streaming/telephony/server/base.py
@@ -101,6 +101,8 @@ class TelephonyServer:
 
         self.router.add_api_route("/recordings/{conversation_id}", self.recordings, methods=["GET", "POST"])
         self.logger.info(f"Set up recordings endpoint at https://{self.base_url}/recordings/{{conversation_id}}")
+
+        self.router.add_api_route("/configurations", self.get_telephony_configuration, "")
  
     def events(self, request: Request):
         return Response()
@@ -191,6 +193,11 @@ class TelephonyServer:
             )
             await telephony_client.end_call(call_config.vonage_uuid)
         return {"id": conversation_id}
+
+    def get_telephony_configuration(self):
+        return {
+            "not": "implemented"
+        }
 
     def get_router(self) -> APIRouter:
         return self.router

--- a/vocode/streaming/utils/state_manager.py
+++ b/vocode/streaming/utils/state_manager.py
@@ -42,7 +42,7 @@ class ConversationStateManager:
         self._conversation.transcriber.is_muted = True
 
     def disable_synthetic_hold(self):
-        self.unmute_agent
+        self.unmute_agent()
         self._conversation.transcriber.is_muted = False
 
     def get_conversation(self):

--- a/vocode/streaming/utils/state_manager.py
+++ b/vocode/streaming/utils/state_manager.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Optional
 from vocode.streaming.models.message import BaseMessage
 from vocode.streaming.models.transcriber import EndpointingConfig
 from vocode.streaming.agent.base_agent import AgentResponseMessage
+from vocode.streaming.models.synthetic_hold import SyntheticHoldConfig
 
 if TYPE_CHECKING:
     from vocode.streaming.streaming_conversation import StreamingConversation
@@ -43,8 +44,8 @@ class ConversationStateManager:
     def unmute_caller(self):
         self._conversation.transcriber.is_muted = False
 
-    def enable_synthetic_hold(self):
-        self._conversation.start_on_hold()
+    def enable_synthetic_hold(self, synthetic_hold_config: SyntheticHoldConfig):
+        self._conversation.start_on_hold(hold_config=synthetic_hold_config)
 
     def disable_synthetic_hold(self):
         self._conversation.stop_on_hold()

--- a/vocode/streaming/utils/state_manager.py
+++ b/vocode/streaming/utils/state_manager.py
@@ -37,6 +37,17 @@ class ConversationStateManager:
     def unmute_agent(self):
         self._conversation.agent.is_muted = False
 
+    def enable_synthetic_hold(self):
+        self.mute_agent()
+        self._conversation.transcriber.is_muted = True
+
+    def disable_synthetic_hold(self):
+        self.unmute_agent
+        self._conversation.transcriber.is_muted = False
+
+    def get_conversation(self):
+        return self._conversation
+
     async def terminate_conversation(self):
         await self._conversation.terminate()
 

--- a/vocode/streaming/utils/state_manager.py
+++ b/vocode/streaming/utils/state_manager.py
@@ -35,29 +35,19 @@ class ConversationStateManager:
         self._conversation.agent.is_muted = True
 
     def unmute_agent(self):
-        if self._conversation.is_caller_on_hold:
-            print("Unable to unmute agent, the caller is on hold.")
-        else:
-            self._conversation.agent.is_muted = False
+        self._conversation.agent.is_muted = False
 
     def mute_caller(self):
         self._conversation.transcriber.is_muted = True
 
     def unmute_caller(self):
-        if self._conversation.is_caller_on_hold:
-            print("Unable to unmute caller, the caller is on hold.")
-        else:
-            self._conversation.transcriber.is_muted = False
+        self._conversation.transcriber.is_muted = False
 
     def enable_synthetic_hold(self):
-        self.mute_caller()
-        self.mute_agent()
         self._conversation.start_on_hold()
 
     def disable_synthetic_hold(self):
         self._conversation.stop_on_hold()
-        self.unmute_agent()
-        self.unmute_caller()
 
     def get_conversation(self):
         return self._conversation

--- a/vocode/streaming/utils/state_manager.py
+++ b/vocode/streaming/utils/state_manager.py
@@ -45,7 +45,7 @@ class ConversationStateManager:
     def disable_synthetic_hold(self):
         self.unmute_agent()
         self._conversation.transcriber.is_muted = False
-        self._conversation.is_caller_on_hold = True
+        self._conversation.is_caller_on_hold = False
 
     def get_conversation(self):
         return self._conversation

--- a/vocode/streaming/utils/state_manager.py
+++ b/vocode/streaming/utils/state_manager.py
@@ -40,10 +40,12 @@ class ConversationStateManager:
     def enable_synthetic_hold(self):
         self.mute_agent()
         self._conversation.transcriber.is_muted = True
+        self._conversation.is_caller_on_hold = True
 
     def disable_synthetic_hold(self):
         self.unmute_agent()
         self._conversation.transcriber.is_muted = False
+        self._conversation.is_caller_on_hold = True
 
     def get_conversation(self):
         return self._conversation

--- a/vocode/streaming/utils/state_manager.py
+++ b/vocode/streaming/utils/state_manager.py
@@ -40,19 +40,24 @@ class ConversationStateManager:
         else:
             self._conversation.agent.is_muted = False
 
-    def enable_synthetic_hold(self):
-        self._conversation.is_caller_on_hold = True
+    def mute_caller(self):
         self._conversation.transcriber.is_muted = True
-        self.mute_agent()
 
-        task_handle = asyncio.create_task(self._conversation._on_hold_task())
-        self._conversation.background_tasks.add(task_handle)
-        task_handle.add_done_callback(self._conversation.background_tasks.discard)
+    def unmute_caller(self):
+        if self._conversation.is_caller_on_hold:
+            print("Unable to unmute caller, the caller is on hold.")
+        else:
+            self._conversation.transcriber.is_muted = False
+
+    def enable_synthetic_hold(self):
+        self.mute_caller()
+        self.mute_agent()
+        self._conversation.start_on_hold()
 
     def disable_synthetic_hold(self):
+        self._conversation.stop_on_hold()
         self.unmute_agent()
-        self._conversation.transcriber.is_muted = False
-        self._conversation.is_caller_on_hold = False
+        self.unmute_caller()
 
     def get_conversation(self):
         return self._conversation


### PR DESCRIPTION
adds the ability to "put caller on hold". ~~right now that means silence where the agent can neither hear nor say anything. the `__on_hold_task` keeps marking that the agent spoke as to prevent reengagement audio from being fired~~

~~Next steps are to pump in some audio while the caller is "on hold"~~

two coroutines are launched, one to prevent reengagement, and one to pump audio chunks from a remote source to twilio directly.

there's now a SyntheticHoldConfig available to tools that manages setting this up. NOTE: if you do NOT use Twilio, the audio will not be sent to caller, it's the only output_device configured at this time