### PR TITLE
Fixing issue with the agent reengaging incorrectly

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -155,10 +155,11 @@ class StreamingConversation(Generic[OutputDeviceType]):
             elif transcription.message.strip() == "":
                 self.conversation.logger.info("Ignoring empty transcription")
                 self.conversation.is_human_speaking = False
-                return
+                # return
             # otherwise mark the message as last time the human spoke
             else:
                 self.conversation.mark_last_final_transcript_from_human()
+                self.conversation.is_human_speaking = True
             # If the human is not speaking but there is an interrupt,
             # we should send the interrupt to the agent and log that the human is speaking
             # case: this happens when there is an agent speaking and the human needs to interrupt them.
@@ -203,7 +204,6 @@ class StreamingConversation(Generic[OutputDeviceType]):
             # else:
             #     self.kill_tasks_when_human_is_talking()
             #     self.conversation.broadcast_interrupt()
-            self.conversation.logger.debug(f"*******Is a human speaking currenltly: {self.conversation.is_human_speaking}*****")
 
     class FillerAudioWorker(InterruptibleAgentResponseWorker):
         """

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -195,10 +195,10 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 )
                 self.output_queue.put_nowait(event)
                 self.conversation.mark_last_final_transcript_from_human()
-                # self.conversation.is_human_speaking = False
-            else:
-                self.kill_tasks_when_human_is_talking()
-                self.conversation.broadcast_interrupt()
+                self.conversation.is_human_speaking = False
+            # else:
+            #     self.kill_tasks_when_human_is_talking()
+            #     self.conversation.broadcast_interrupt()
 
     class FillerAudioWorker(InterruptibleAgentResponseWorker):
         """

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -142,17 +142,15 @@ class StreamingConversation(Generic[OutputDeviceType]):
             # this is only enabled in experimental mode (though this should be relooked)
             # send interrupt and mark message as last time the human spoke
             if transcription.message.strip() == "<INTERRUPT>" and transcription.confidence == 1.0:
-                # print("Human speaking interrupt")
-                # # if self.conversation.transcriber.get_transcriber_config().experimental:
-                    # print("In experimental")
+                if self.conversation.transcriber.get_transcriber_config().experimental:
                     self.conversation.is_human_speaking = True
                     self.conversation.mark_last_final_transcript_from_human()
                     self.conversation.broadcast_interrupt()
                     return
-                # else:
-                #     return
+                else:
+                    return
             # If the message was empty (silence), we ignore it
-            elif transcription.message.strip() == "":
+            if transcription.message.strip() == "":
                 self.conversation.logger.info("Ignoring empty transcription")
                 return
             # otherwise mark the message as last time the human spoke
@@ -171,13 +169,11 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 )
                 if self.conversation.current_transcription_is_interrupt:
                     self.conversation.logger.debug("sending interrupt")
-                # self.conversation.logger.debug("Human started speaking")
-                # self.conversation.is_human_speaking = True
 
             transcription.is_interrupt = (
                 self.conversation.current_transcription_is_interrupt
             )
-            # self.conversation.is_human_speaking = not transcription.is_final
+            self.conversation.is_human_speaking = not transcription.is_final
 
             # if this is the final transcript, log out data
             # create a new event and put it on the queue

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -169,6 +169,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 )
                 if self.conversation.current_transcription_is_interrupt:
                     self.conversation.logger.debug("sending interrupt")
+                self.conversation.logger.debug("Human started speaking")
 
             transcription.is_interrupt = (
                 self.conversation.current_transcription_is_interrupt

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -174,7 +174,6 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 self.conversation.current_transcription_is_interrupt
             )
             self.conversation.is_human_speaking = not transcription.is_final
-
             # if this is the final transcript, log out data
             # create a new event and put it on the queue
             # set last human utterance time and reset `is_human_speaking` boolean
@@ -195,7 +194,6 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 )
                 self.output_queue.put_nowait(event)
                 self.conversation.mark_last_final_transcript_from_human()
-                self.conversation.is_human_speaking = False
             # else:
             #     self.kill_tasks_when_human_is_talking()
             #     self.conversation.broadcast_interrupt()

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -154,12 +154,11 @@ class StreamingConversation(Generic[OutputDeviceType]):
             # If the message was empty (silence), we ignore it
             elif transcription.message.strip() == "":
                 self.conversation.logger.info("Ignoring empty transcription")
-                self.conversation.is_human_speaking = False
-                # return
+                return
             # otherwise mark the message as last time the human spoke
             else:
                 self.conversation.mark_last_final_transcript_from_human()
-                self.conversation.is_human_speaking = True
+                # self.conversation.is_human_speaking = True
             # If the human is not speaking but there is an interrupt,
             # we should send the interrupt to the agent and log that the human is speaking
             # case: this happens when there is an agent speaking and the human needs to interrupt them.

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -150,7 +150,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
             # send interrupt and mark message as last time the human spoke
             if transcription.message.strip() == "<INTERRUPT>" and transcription.confidence == 1.0:
                 if self.conversation.transcriber.get_transcriber_config().experimental:
-                    self.conversation.is_human_speaking = True
+                    # self.conversation.is_human_speaking = True
                     self.conversation.mark_last_final_transcript_from_human()
                     self.conversation.broadcast_interrupt()
                     return
@@ -195,7 +195,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 )
                 self.output_queue.put_nowait(event)
                 self.conversation.mark_last_final_transcript_from_human()
-                self.conversation.is_human_speaking = False
+                # self.conversation.is_human_speaking = False
             else:
                 self.kill_tasks_when_human_is_talking()
                 self.conversation.broadcast_interrupt()

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -171,8 +171,8 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 )
                 if self.conversation.current_transcription_is_interrupt:
                     self.conversation.logger.debug("sending interrupt")
-                self.conversation.logger.debug("Human started speaking")
-                self.conversation.is_human_speaking = True
+                # self.conversation.logger.debug("Human started speaking")
+                # self.conversation.is_human_speaking = True
 
             transcription.is_interrupt = (
                 self.conversation.current_transcription_is_interrupt


### PR DESCRIPTION
The agent would attempt to reengage the user in the middle of a sentence due to an issue where the code would mark that the user last spoke at the start of their utterance, meaning that if they spoke for a while, the system would assume they need to be reengaged. Now we properly denote that the utterance is still going on so that unless there is silence, this timeout would not happen.